### PR TITLE
Use CP1252 encoding for CAOS injection instead of UTF8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj
 packages
 .vs
 .suo
+.idea/.idea.CAOS

--- a/CAOS/CaosInjector.cs
+++ b/CAOS/CaosInjector.cs
@@ -13,6 +13,7 @@ namespace CAOS
         private EventWaitHandle ResultEventHandle;
         private EventWaitHandle RequestRventHandle;
         private string GameName;
+        private static readonly Encoding Encoder = Encoding.GetEncoding(1252);
 
         public CaosInjector(string gameName)
         {
@@ -113,7 +114,7 @@ namespace CAOS
         {
             //Need more exception checking here - JG
             InitInjector();
-            byte[] CaosBytes = Encoding.UTF8.GetBytes(Action + "\n" + CaosAsString + "\n");
+            byte[] CaosBytes = Encoder.GetBytes(Action + "\n" + CaosAsString + "\n");
             int BufferPosition = 24;
             Mutex.WaitOne(1000);
             foreach (byte Byte in CaosBytes)
@@ -142,7 +143,7 @@ namespace CAOS
             Mutex.ReleaseMutex();
             CloseInjector();
             Thread.Sleep(50);
-            return new CaosResult(ResultCode, Encoding.UTF8.GetString(ResultBytes), ProcessID);
+            return new CaosResult(ResultCode, Encoder.GetString(ResultBytes), ProcessID);
         }
 
         public int ProcessID()

--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -14,6 +14,7 @@ namespace ConsoleApp1
             {
                 TryCatchStrategy(injector);
                 TryReturnBoolStrategy(injector);
+                TryCp1252Encoding(injector);
             }
             else
             {
@@ -52,6 +53,38 @@ namespace ConsoleApp1
                     Console.WriteLine(result.Content);
                     //Just try to do it, we don't care about the results
                     injector.TryExecuteCaos("targ norn doif targ <> null sezz \"Yo yo! What up?\" endi");
+                }
+                else
+                {
+                    Debug.Assert(result.ResultCode != 0);
+                    Console.WriteLine($"Error Code: {result.ResultCode}");
+                }
+            }
+            else
+            {
+                Console.WriteLine("Execution failed. Game may have exited.");
+            }
+        }
+
+        private static void TryCp1252Encoding(CaosInjector injector)
+        {
+            CaosResult result;
+            var testString = "bonjour, ça va? très bien!";
+            if (injector.TryExecuteCaos($"outs \"{testString}\"", out result))
+            {
+                if (result.Success)
+                {
+                    var stringWithoutTerminator = result.Content.Substring(0, result.Content.Length - 1);
+                    if (stringWithoutTerminator == testString)
+                    {
+                        Console.WriteLine("CP1252 Encoding was used successfully");
+                    }
+                    else
+                    {
+                        Console.Error.WriteLine(
+                            "CP1252 result was unexpected. Expected: '" + testString +
+                                                "'; Found: '" + result.Content + "'");
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Creatures expects CAOS to be text encoded with CP1252 encoding. Use of UTF8 causes encoding issues and garbled text.

This pull request replaces UTF8 encoding/decoding with CP1252
